### PR TITLE
Add rename-flag command and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Finds all transactions that are marked with #flag [amount], and finds their sum.
 Finds all transactions that are marked with #flag [amount], and removes the flag and amount. Doesn't search subtransactions. Assumes flag/amount is at end of the memo.
 
 ```bash
+./ynab_cli.py rename-flag <old_flag> <new_flag>
+```
+Finds all transactions with old_flag and renames it to new_flag.
+
+```bash
 ./ynab_cli.py flag-category <flag>
 ```
 Pick a category and flag all of its transactions with the given flag.


### PR DESCRIPTION
- Introduced a new command `rename-flag` to rename flags in transaction memos.
- Added helper functions for normalizing flags and retrieving all transactions.
- Updated README.md to document the new command and its usage.